### PR TITLE
Fix a require 'answer' at babylonian-method tests

### DIFF
--- a/babylonian-method/babylonian-test.js
+++ b/babylonian-method/babylonian-test.js
@@ -1,4 +1,4 @@
-const squareRoot = require('./answer')
+const squareRoot = require('./babylonian')
 const test = require('tape')
 
 test('it calculates an integer square root', assert => {


### PR DESCRIPTION
I was doing the challenge and when I ran `node babylonian-test.js` the test broke.
__babylonian-test.js__ has a `require('./answer')`, but there is no __answer.js__ at babylonian-method folder.

The file which provides the squareRoot function is __babylonian.js__.